### PR TITLE
Add navigation to navigate to plant details

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,13 +26,20 @@
         android:theme="@style/Theme.Splash">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/Theme.Splash"
             android:exported="true"
+            android:theme="@style/Theme.Splash"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:host="leafy"
+                    android:scheme="app" />
             </intent-filter>
         </activity>
         <service

--- a/app/src/main/java/com/ujizin/leafy/BackHandler.kt
+++ b/app/src/main/java/com/ujizin/leafy/BackHandler.kt
@@ -1,0 +1,28 @@
+package com.ujizin.leafy
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.launch
+
+@Composable
+fun BackHandler(
+    navController: NavHostController,
+    drawerState: DrawerState,
+    onFinish: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val isDrawerOpen by rememberUpdatedState(drawerState.isOpen)
+
+    when {
+        isDrawerOpen -> androidx.activity.compose.BackHandler {
+            scope.launch { drawerState.close() }
+        }
+        else -> androidx.activity.compose.BackHandler {
+            if (!navController.navigateUp()) onFinish()
+        }
+    }
+}

--- a/app/src/main/java/com/ujizin/leafy/MainActivity.kt
+++ b/app/src/main/java/com/ujizin/leafy/MainActivity.kt
@@ -1,27 +1,14 @@
 package com.ujizin.leafy
 
-import android.content.Intent
 import android.os.Bundle
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.ujizin.leafy.alarm.AlarmService
-import com.ujizin.leafy.core.navigation.Destination
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -38,42 +25,17 @@ class MainActivity : AppCompatActivity() {
             AppConfiguration {
                 val navController = rememberNavController()
                 val drawerState = rememberDrawerState(DrawerValue.Closed)
-                LaunchPlantDetail(navController)
 
-                BackHandler(navController, drawerState)
+                BackHandler(
+                    navController = navController,
+                    drawerState = drawerState,
+                    onFinish = ::finish,
+                )
 
                 LeafyNavigation(
                     navController = navController,
                     drawerState = drawerState,
                 )
-            }
-        }
-    }
-
-    @Composable
-    private fun BackHandler(
-        navController: NavHostController,
-        drawerState: DrawerState,
-    ) {
-        val scope = rememberCoroutineScope()
-        val isDrawerOpen by rememberUpdatedState(drawerState.isOpen)
-
-        when {
-            isDrawerOpen -> BackHandler { scope.launch { drawerState.close() } }
-            else -> BackHandler { if (!navController.navigateUp()) finish() }
-        }
-    }
-
-    @Composable
-    private fun LaunchPlantDetail(navController: NavHostController) {
-        val plantId = remember { intent.getLongExtra(AlarmService.PLANT_ID, -1) }
-        LaunchedEffect(plantId) {
-            if (plantId != -1L) {
-                if (intent.action == AlarmService.STOP_ACTION) {
-                    stopService(Intent(this@MainActivity, AlarmService::class.java))
-                }
-
-                navController.navigate(Destination.PlantDetails(plantId))
             }
         }
     }

--- a/core/local/src/main/java/com/ujizin/leafy/core/local/model/UserStore.kt
+++ b/core/local/src/main/java/com/ujizin/leafy/core/local/model/UserStore.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class UserStore(
     val nickname: String,
     val theme: String? = null,
-    val language: String? = null,
+    val language: String,
     val dynamicColor: Boolean,
     val createdAt: String? = null,
 ) {
@@ -14,11 +14,10 @@ data class UserStore(
     companion object {
         private const val DEFAULT_NICKNAME = "User"
 
-        // TODO get a new Date library to use on created at
         fun default() = UserStore(
             nickname = DEFAULT_NICKNAME,
             theme = null,
-            language = null,
+            language = "EN",
             dynamicColor = true,
             createdAt = " ",
         )

--- a/core/navigation/src/main/java/com/ujizin/leafy/core/navigation/Destination.kt
+++ b/core/navigation/src/main/java/com/ujizin/leafy/core/navigation/Destination.kt
@@ -1,5 +1,7 @@
 package com.ujizin.leafy.core.navigation
 
+import android.net.Uri
+import androidx.core.net.toUri
 import kotlinx.serialization.Serializable
 
 sealed interface Destination {
@@ -29,8 +31,18 @@ sealed interface Destination {
     data object About : Destination
 
     @Serializable
-    data class PlantDetails(val plantId: Long) : Destination
+    data class PlantDetails(val plantId: Long) : Destination {
+        companion object {
+            fun createDeeplink(plantId: Long): Uri = "$DEEPLINK_URL/$plantId".toUri()
+
+            const val DEEPLINK_URL = "$BASE_PATH/plant"
+        }
+    }
 
     @Serializable
     data class PlantEdit(val plantId: Long) : Destination
+
+    companion object {
+        const val BASE_PATH = "app://leafy"
+    }
 }

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/implementation/PlantRepositoryImpl.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/implementation/PlantRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ujizin.leafy.core.repository.implementation
 
 import com.ujizin.leafy.core.repository.datasource.PlantDataSource
 import com.ujizin.leafy.core.repository.mapper.PlantMapper
+import com.ujizin.leafy.core.repository.utils.createDraft
 import com.ujizin.leafy.domain.dispatcher.IoDispatcher
 import com.ujizin.leafy.domain.model.Plant
 import com.ujizin.leafy.domain.repository.PlantRepository
@@ -46,7 +47,7 @@ internal class PlantRepositoryImpl @Inject constructor(
     }.flowOn(dispatcher)
 
     override fun getDraftPlant() = flow {
-        emit(dataSource.getDraftPlant()?.let(mapper::toDomain) ?: Plant.createDraft())
+        emit(dataSource.getDraftPlant()?.let(mapper::toDomain) ?: createDraft())
     }.flowOn(dispatcher)
 
     override fun updateDraftPlant(plant: Plant) = flow {

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/implementation/RingtoneRepositoryImpl.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/implementation/RingtoneRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.ujizin.leafy.core.repository.implementation
 
 import android.content.Context
 import android.media.RingtoneManager
-import android.net.Uri
 import com.ujizin.leafy.domain.dispatcher.IoDispatcher
 import com.ujizin.leafy.domain.model.Ringtone
 import com.ujizin.leafy.domain.repository.RingtoneRepository
@@ -32,7 +31,7 @@ internal class RingtoneRepositoryImpl @Inject constructor(
                 val uri = cursor.getString(RingtoneManager.URI_COLUMN_INDEX)
                 val id = cursor.getString(RingtoneManager.ID_COLUMN_INDEX)
 
-                ringtoneList.add(Ringtone(id, title, Uri.parse("$uri/$id")))
+                ringtoneList.add(Ringtone(id, title, "$uri/$id"))
             } while (cursor.moveToNext())
         }
 

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/mapper/PlantMapper.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/mapper/PlantMapper.kt
@@ -1,7 +1,6 @@
 package com.ujizin.leafy.core.repository.mapper
 
 import com.ujizin.leafy.domain.model.Plant
-import java.io.File
 import com.ujizin.leafy.core.repository.model.Plant as DataPlant
 
 /**
@@ -16,7 +15,7 @@ internal class PlantMapper {
             id,
             title,
             description,
-            File(filePath),
+            filePath,
             favorite,
             albumId,
         )
@@ -25,6 +24,6 @@ internal class PlantMapper {
     fun toRepo(plants: List<Plant>) = plants.map { toRepo(it) }
 
     fun toRepo(plant: Plant) = with(plant) {
-        DataPlant(id, title, file.absolutePath, description, favorite, albumId)
+        DataPlant(id, title, filePath, description, favorite, albumId)
     }
 }

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/mapper/UserMapper.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/mapper/UserMapper.kt
@@ -14,7 +14,7 @@ internal class UserMapper {
         User(
             nickname = nickname,
             settings = User.Settings(
-                language = language?.let(Language::valueOf) ?: Language.systemLanguage,
+                language = language.let(Language::valueOf),
                 theme = theme?.let(Theme::valueOf) ?: Theme.System,
                 dynamicColor = dynamicColor,
             ),

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/model/User.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/model/User.kt
@@ -10,6 +10,6 @@ package com.ujizin.leafy.core.repository.model
 data class User(
     val nickname: String,
     val theme: String?,
-    val language: String?,
+    val language: String,
     val dynamicColor: Boolean,
 )

--- a/core/repository/src/main/java/com/ujizin/leafy/core/repository/utils/PlantUtils.kt
+++ b/core/repository/src/main/java/com/ujizin/leafy/core/repository/utils/PlantUtils.kt
@@ -1,0 +1,12 @@
+package com.ujizin.leafy.core.repository.utils
+
+import com.ujizin.leafy.domain.model.Plant
+import java.io.File
+import java.util.UUID
+
+fun createDraft() = Plant(
+    title = "untitled",
+    filePath = File.createTempFile(UUID.randomUUID().toString(), ".jpg").path,
+    description = "no description",
+    favorite = false,
+)

--- a/core/ui/src/main/java/com/ujizin/leafy/core/ui/components/card/CardPlant.kt
+++ b/core/ui/src/main/java/com/ujizin/leafy/core/ui/components/card/CardPlant.kt
@@ -21,7 +21,7 @@ fun CardPlant(
 ) {
     CardImage(
         modifier = modifier,
-        data = plant.file,
+        data = plant.filePath,
         contentDescription = plant.title,
         onClick = onClick,
     ) {

--- a/core/ui/src/main/java/com/ujizin/leafy/core/ui/components/navigation/bottombar/NavigationBar.kt
+++ b/core/ui/src/main/java/com/ujizin/leafy/core/ui/components/navigation/bottombar/NavigationBar.kt
@@ -75,14 +75,6 @@ private fun BottomNavigationBar(
 }
 
 fun NavController.navigateToItem(item: NavItem) {
-    val route = currentBackStackEntry?.destination?.route
-//    if (route == item.destination.route) return
-//
-//    if (item.destination.route == graph.startDestinationRoute) {
-//        popBackStack()
-//        return
-//    }
-
     navigate(item.destination) {
         graph.startDestinationRoute?.let { route ->
             popUpTo(route) {

--- a/core/ui/src/main/java/com/ujizin/leafy/core/ui/extensions/PlantExtensions.kt
+++ b/core/ui/src/main/java/com/ujizin/leafy/core/ui/extensions/PlantExtensions.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.core.content.FileProvider
 import com.ujizin.leafy.core.components.R
 import com.ujizin.leafy.domain.model.Plant
+import java.io.File
 
 fun Plant.share(context: Context) {
     val intent = Intent().apply {
@@ -12,7 +13,7 @@ fun Plant.share(context: Context) {
         val uri = FileProvider.getUriForFile(
             context,
             "${context.packageName}.provider",
-            file,
+            File(filePath),
         )
         setDataAndType(uri, "image/*")
         putExtra(Intent.EXTRA_STREAM, uri)

--- a/core/ui/src/main/java/com/ujizin/leafy/core/ui/local/LocalUser.kt
+++ b/core/ui/src/main/java/com/ujizin/leafy/core/ui/local/LocalUser.kt
@@ -1,6 +1,27 @@
 package com.ujizin.leafy.core.ui.local
 
 import androidx.compose.runtime.compositionLocalOf
+import com.ujizin.leafy.domain.model.Language.EN
+import com.ujizin.leafy.domain.model.Language.PT
+import com.ujizin.leafy.domain.model.Theme
 import com.ujizin.leafy.domain.model.User
+import com.ujizin.leafy.domain.model.User.Settings
+import java.util.Locale
 
-val LocalUser = compositionLocalOf { User.default }
+private val DefaultLanguage
+    get() = when (Locale.getDefault().language) {
+        "pt" -> PT
+        else -> EN
+    }
+
+private val DefaultUser: User
+    get() = User(
+        nickname = "User",
+        settings = Settings(
+            theme = Theme.System,
+            language = DefaultLanguage,
+            dynamicColor = true,
+        ),
+    )
+
+val LocalUser = compositionLocalOf { DefaultUser }

--- a/domain/src/main/java/com/ujizin/leafy/domain/model/Language.kt
+++ b/domain/src/main/java/com/ujizin/leafy/domain/model/Language.kt
@@ -1,16 +1,5 @@
 package com.ujizin.leafy.domain.model
 
-import java.util.Locale
-
 enum class Language {
-    PT, EN;
-
-    companion object {
-
-        val systemLanguage: Language
-            get() = when (Locale.getDefault().language) {
-                "pt" -> PT
-                else -> EN
-            }
-    }
+    PT, EN
 }

--- a/domain/src/main/java/com/ujizin/leafy/domain/model/Plant.kt
+++ b/domain/src/main/java/com/ujizin/leafy/domain/model/Plant.kt
@@ -1,14 +1,11 @@
 package com.ujizin.leafy.domain.model
 
-import java.io.File
-import java.util.UUID
-
 /***
  * Plant Model
  *
  * @param id the plant id
  * @param title the plant title
- * @param file the file path of the plant
+ * @param filePath the file path of the plant
  * @param description the plant description
  * @param favorite indicates if plant is favorite
  * @param albumId the album id linked to the plant
@@ -17,16 +14,7 @@ data class Plant(
     val id: Long = 0,
     val title: String,
     val description: String,
-    val file: File,
+    val filePath: String,
     val favorite: Boolean,
     val albumId: Long? = null,
-) {
-    companion object {
-        fun createDraft() = Plant(
-            title = "untitled",
-            file = File.createTempFile(UUID.randomUUID().toString(), ".jpg"),
-            description = "no description",
-            favorite = false,
-        )
-    }
-}
+)

--- a/domain/src/main/java/com/ujizin/leafy/domain/model/Ringtone.kt
+++ b/domain/src/main/java/com/ujizin/leafy/domain/model/Ringtone.kt
@@ -1,7 +1,5 @@
 package com.ujizin.leafy.domain.model
 
-import android.net.Uri
-
 /**
  * Ringtone model
  *
@@ -12,5 +10,5 @@ import android.net.Uri
 data class Ringtone(
     val id: String,
     val title: String,
-    val uri: Uri,
+    val uriContent: String,
 )

--- a/domain/src/main/java/com/ujizin/leafy/domain/model/User.kt
+++ b/domain/src/main/java/com/ujizin/leafy/domain/model/User.kt
@@ -23,18 +23,6 @@ data class User(
         val language: Language,
         val dynamicColor: Boolean,
     )
-
-    companion object {
-        val default: User
-            get() = User(
-                nickname = "User",
-                settings = Settings(
-                    theme = Theme.System,
-                    language = Language.systemLanguage,
-                    dynamicColor = true,
-                ),
-            )
-    }
 }
 
 /**

--- a/domain/src/main/java/com/ujizin/leafy/domain/usecase/plant/add/AddDraftPlantUseCaseImpl.kt
+++ b/domain/src/main/java/com/ujizin/leafy/domain/usecase/plant/add/AddDraftPlantUseCaseImpl.kt
@@ -1,28 +1,28 @@
 package com.ujizin.leafy.domain.usecase.plant.add
 
 import com.ujizin.leafy.domain.repository.PlantRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.map
 import java.io.File
 
 internal class AddDraftPlantUseCaseImpl(
     private val plantRepository: PlantRepository,
 ) : AddDraftPlantUseCase {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun invoke(
         title: String?,
         file: File?,
         description: String?,
-    ): Flow<Unit> = flow {
-        val plant = plantRepository.getDraftPlant().first().let { plant ->
-            plant.copy(
-                title = title ?: plant.title,
-                description = description ?: plant.description,
-                file = file ?: plant.file,
-            )
-        }
-
-        emit(plantRepository.updateDraftPlant(plant).first())
+    ): Flow<Unit> = plantRepository.getDraftPlant().map { plant ->
+        plant.copy(
+            title = title ?: plant.title,
+            description = description ?: plant.description,
+            filePath = file?.path ?: plant.filePath,
+        )
+    }.flatMapConcat { plant ->
+        plantRepository.updateDraftPlant(plant)
     }
 }

--- a/domain/src/test/java/com/ujizin/leafy/domain/PlantUseCaseTest.kt
+++ b/domain/src/test/java/com/ujizin/leafy/domain/PlantUseCaseTest.kt
@@ -23,7 +23,6 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.io.File
 
 @ExperimentalCoroutinesApi
 class PlantUseCaseTest {
@@ -68,9 +67,9 @@ class PlantUseCaseTest {
     @Test
     fun `when load plant then expect return plants on repository`() = runTest {
         val expectedPlants = listOf(
-            Plant(id = 1, "", "", File(""), false),
-            Plant(id = 2, "", "", File(""), false),
-            Plant(id = 3, "", "", File(""), false),
+            Plant(id = 1, "", "", "", false),
+            Plant(id = 2, "", "", "", false),
+            Plant(id = 3, "", "", "", false),
         )
 
         every { plantRepository.getPlants() } returns flowOf(expectedPlants)

--- a/domain/src/test/java/com/ujizin/leafy/domain/RingtoneUseCaseTest.kt
+++ b/domain/src/test/java/com/ujizin/leafy/domain/RingtoneUseCaseTest.kt
@@ -8,7 +8,6 @@ import com.ujizin.leafy.domain.usecase.ringtone.load.LoadRingtonesUseCaseImpl
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.test.runTest
@@ -18,7 +17,6 @@ import org.junit.Rule
 import org.junit.Test
 
 class RingtoneUseCaseTest {
-    // TODO add unit test - #11
 
     @get:Rule
     var mainDispatcherRule = TestDispatcherRule()
@@ -49,7 +47,7 @@ class RingtoneUseCaseTest {
 
     companion object {
         private val ringtones = List(10) {
-            Ringtone("$it", "title-$it", mockk())
+            Ringtone("$it", "title-$it", "uriContent-$it")
         }
     }
 }

--- a/features/alarm/src/main/AndroidManifest.xml
+++ b/features/alarm/src/main/AndroidManifest.xml
@@ -3,13 +3,14 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application>
+        <activity android:name="com.ujizin.leafy.alarm.receiver.StopPlantServiceActivity" />
         <receiver
             android:name="com.ujizin.leafy.alarm.receiver.AlarmReceiver"
             android:enabled="true"
@@ -17,7 +18,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/extensions/AlarmExtensions.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/extensions/AlarmExtensions.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
+import com.ujizin.leafy.alarm.AlarmService
 
 /**
  * Get alarm manager instance from context
@@ -34,3 +35,12 @@ val AlarmManager.hasAlarmPermission
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> canScheduleExactAlarms()
         else -> true
     }
+
+/**
+ * Get alarm service intent
+ * */
+internal fun Context.getAlarmIntent(
+    action: String? = null,
+) = Intent(this, AlarmService::class.java).apply {
+    this.action = action
+}

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/extensions/RingtoneExtensions.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/extensions/RingtoneExtensions.kt
@@ -13,5 +13,5 @@ fun ModalValue<Ringtone>?.orDefault(context: Context) = this ?: run {
 fun getDefaultRingtone(context: Context): Ringtone {
     val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
     val ringtone = RingtoneManager.getRingtone(context, uri)
-    return Ringtone("0", ringtone.getTitle(context), uri)
+    return Ringtone("0", ringtone.getTitle(context), uri.toString())
 }

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/receiver/AlarmReceiver.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/receiver/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.ujizin.leafy.alarm.AlarmService
+import com.ujizin.leafy.alarm.extensions.getAlarmIntent
 import com.ujizin.leafy.alarm.scheduler.AlarmScheduler
 import com.ujizin.leafy.alarm.usecase.SchedulePlantAlarmUseCase
 import com.ujizin.leafy.core.components.R
@@ -64,7 +65,7 @@ class AlarmReceiver : BroadcastReceiver() {
     private fun Context.getAlarmServiceIntent(
         plant: Plant,
         ringtone: String?,
-    ) = Intent(this, AlarmService::class.java).apply {
+    ) = getAlarmIntent().apply {
         putExtra(AlarmService.PLANT_ID, plant.id)
         putExtra(AlarmService.TITLE_ARG, getString(R.string.app_name))
         putExtra(AlarmService.DESCRIPTION_ARG, plant.title)

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/receiver/StopPlantServiceActivity.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/receiver/StopPlantServiceActivity.kt
@@ -1,0 +1,28 @@
+package com.ujizin.leafy.alarm.receiver
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.ujizin.leafy.alarm.AlarmService
+import com.ujizin.leafy.alarm.extensions.getAlarmIntent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class StopPlantServiceActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        stopAlarmService(this)
+        finish()
+    }
+
+    private fun stopAlarmService(context: Context?) {
+        val stopAlarmIntent = context?.getAlarmIntent(AlarmService.STOP_ACTION)
+        context?.startService(stopAlarmIntent)
+    }
+
+    companion object {
+        fun getIntent(context: Context) = Intent(context, StopPlantServiceActivity::class.java)
+    }
+}

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmSection.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmSection.kt
@@ -16,12 +16,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ujizin.leafy.alarm.extensions.alarmManager
 import com.ujizin.leafy.alarm.extensions.hasAlarmPermission

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmSection.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmSection.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -127,7 +128,7 @@ fun AlarmScreen(
 ) {
     val context = LocalContext.current
     val ringtonePlayer = remember(ringtone) {
-        RingtoneManager.getRingtone(context, ringtone.value.uri)
+        RingtoneManager.getRingtone(context, ringtone.value.uriContent.toUri())
     }
     var ringtoneShowModal by remember { mutableStateOf(false) }
     var repeatShowModal by remember { mutableStateOf(false) }

--- a/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmViewModel.kt
+++ b/features/alarm/src/main/java/com/ujizin/leafy/alarm/ui/AlarmViewModel.kt
@@ -58,10 +58,14 @@ class AlarmViewModel @Inject constructor(
         weekDays: List<WeekDay>,
         onPlantPublished: () -> Unit,
     ) {
-        val ringtoneContent = ringtone.uri.toString()
+        val ringtoneContent = ringtone.uriContent
         loadDraftPlant()
             .mapResult()
-            .map { it.copy(file = it.file.copyAndDelete(File(plantsDir, it.file.name))) }
+            .map {
+                val draftFile = File(it.filePath)
+                val plantFile = File(plantsDir, draftFile.name)
+                it.copy(filePath = draftFile.copyAndDelete(plantFile).absolutePath)
+            }
             .flatMapConcat { plant ->
                 addPlant(plant.copy(id = 0)).flatMapConcat { id ->
                     addAlarm(

--- a/features/alarm/src/test/java/com/ujizin/leafy/alarm/fakes/FakeLoadPlant.kt
+++ b/features/alarm/src/test/java/com/ujizin/leafy/alarm/fakes/FakeLoadPlant.kt
@@ -4,7 +4,6 @@ import com.ujizin.leafy.domain.model.Plant
 import com.ujizin.leafy.domain.result.Result
 import com.ujizin.leafy.domain.usecase.plant.load.LoadPlantUseCase
 import kotlinx.coroutines.flow.flow
-import java.io.File
 
 class FakeLoadPlant(
     private val until: Int = 10,
@@ -24,9 +23,9 @@ class FakeLoadPlant(
             id: Long = 1,
             title: String = "",
             description: String = "",
-            file: File = File("test"),
+            filePath: String = "test",
             favorite: Boolean = false,
             albumId: Long? = null,
-        ) = Plant(id, title, description, file, favorite, albumId)
+        ) = Plant(id, title, description, filePath, favorite, albumId)
     }
 }

--- a/features/plant/src/main/java/com/ujizin/leafy/features/plant/PlantGraph.kt
+++ b/features/plant/src/main/java/com/ujizin/leafy/features/plant/PlantGraph.kt
@@ -2,9 +2,11 @@ package com.ujizin.leafy.features.plant
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.ujizin.leafy.core.navigation.AnimatedEnterTransition
 import com.ujizin.leafy.core.navigation.AnimatedExitTransition
-import com.ujizin.leafy.core.navigation.Destination
+import com.ujizin.leafy.core.navigation.Destination.PlantDetails
+import com.ujizin.leafy.core.navigation.Destination.PlantEdit
 import com.ujizin.leafy.core.ui.extensions.OnClick
 import com.ujizin.leafy.core.ui.extensions.fullSlideInHorizontally
 import com.ujizin.leafy.core.ui.extensions.fullSlideOutHorizontally
@@ -16,15 +18,18 @@ fun NavGraphBuilder.plantGraph(
     enterTransition: AnimatedEnterTransition = { fullSlideInHorizontally() },
     exitTransition: AnimatedExitTransition = { fullSlideOutHorizontally() },
 ) {
-    composable<Destination.PlantDetails>(
+    composable<PlantDetails>(
         enterTransition = enterTransition,
         exitTransition = exitTransition,
+        deepLinks = listOf(
+            navDeepLink<PlantDetails>(basePath = PlantDetails.DEEPLINK_URL),
+        ),
     ) {
         PlantDetailsRoute(
             onBackPressed = onBackPressed,
         )
     }
-    composable<Destination.PlantEdit>(
+    composable<PlantEdit>(
         enterTransition = enterTransition,
         exitTransition = exitTransition,
     ) {

--- a/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/PlantDetailsViewModel.kt
+++ b/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/PlantDetailsViewModel.kt
@@ -33,10 +33,10 @@ class DetailPlantViewModel @Inject constructor(
     private val updateAlarmUseCase: UpdateAlarmUseCase,
 ) : ViewModel() {
 
-    private val plantId: Long = savedStateHandle.toRoute<Destination.PlantDetails>().plantId
+    private val arguments = savedStateHandle.toRoute<Destination.PlantDetails>()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val uiState = loadPlant(plantId)
+    val uiState = loadPlant(arguments.plantId)
         .mapResult()
         .flatMapConcat { plant ->
             loadAlarms(plant.id)
@@ -56,7 +56,7 @@ class DetailPlantViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun deletePlant(plant: Plant, onCompletion: () -> Unit) {
-        deleteAlarmUseCase(plantId)
+        deleteAlarmUseCase(arguments.plantId)
             .flatMapConcat { deletePlantUseCase(plant) }
             .onCompletion { onCompletion() }
             .launchIn(viewModelScope)

--- a/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/ui/PlantDetails.kt
+++ b/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/ui/PlantDetails.kt
@@ -14,7 +14,6 @@ import com.ujizin.leafy.domain.model.Alarm
 import com.ujizin.leafy.domain.model.Plant
 import com.ujizin.leafy.features.plant.detail.DetailPlantUiState
 import com.ujizin.leafy.features.plant.detail.DetailPlantViewModel
-import java.io.File
 
 @Composable
 fun PlantDetailsRoute(
@@ -69,7 +68,7 @@ private fun PlantDetailsPreview() {
                         1,
                         "Plant foo",
                         "Description",
-                        File("foo"),
+                        "foo",
                         false,
                     ),
                     alarms = listOf(),

--- a/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/ui/PlantDetailsContent.kt
+++ b/features/plant/src/main/java/com/ujizin/leafy/features/plant/detail/ui/PlantDetailsContent.kt
@@ -66,7 +66,7 @@ internal fun PlantDetailsContent(
                     .fillMaxWidth()
                     .aspectRatio(1F),
                 animation = Animation.SlideToTop,
-                data = plant.file,
+                data = plant.filePath,
                 elevation = 0.dp,
                 shape = RectangleShape,
                 contentDescription = plant.title,

--- a/features/tasks/src/main/java/com/ujizin/leafy/features/tasks/Tasks.kt
+++ b/features/tasks/src/main/java/com/ujizin/leafy/features/tasks/Tasks.kt
@@ -154,7 +154,7 @@ private fun PlantItem(
             modifier = Modifier
                 .size(80.dp)
                 .clip(MaterialTheme.shapes.small),
-            model = task.plant.file,
+            model = task.plant.filePath,
             contentDescription = task.plant.title,
         )
         Column(modifier = Modifier.padding(start = 8.dp)) {

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -11,6 +11,7 @@ task ktlint(type: JavaExec, group: "verification") {
     main = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt", "--reporter=plain", "--reporter=checkstyle,output=${buildDir}/reports/ktlint/ktlint-checkstyle.xml"
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 check.dependsOn ktlint
@@ -20,4 +21,5 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     main = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }


### PR DESCRIPTION
### What's changed

- Add deeplink to navigate to plant details
- Remove android/java dependencies from Domain Module
- Move responsability of navigate to plant details from MainActivity to AlarmService intent, using [reverse activity trampoline](https://onesignal.com/blog/android-12-notification-open-changes/)
- Add jvmargs to ktlint due to flaky builds